### PR TITLE
CI: Test all supported Python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 #         python-version: ["3.8"]
 #         os: [ubuntu-latest]


### PR DESCRIPTION
Test all currently supported Python versions in CI (3.8 to 3.12).